### PR TITLE
Changed generate rpc call to use the Optimised equihash solver 

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -257,7 +257,7 @@ UniValue generate(const UniValue& params, bool fHelp)
                 solutionTargetChecks.increment();
                 return CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus());
             };
-            bool found = EhBasicSolveUncancellable(n, k, curr_state, validBlock);
+            bool found = EhOptimisedSolveUncancellable(n, k, curr_state, validBlock);
             ehSolverRuns.increment();
             if (found) {
                 goto endloop;


### PR DESCRIPTION
Changed generate rpc call to use the Optimised equihash solver so that regtest is practically usable with 192,7 parameters.